### PR TITLE
Add some missing header includes

### DIFF
--- a/src/lib/case_insensitive_sorter.cc
+++ b/src/lib/case_insensitive_sorter.cc
@@ -21,6 +21,7 @@
 
 #include "case_insensitive_sorter.h"
 #include <boost/filesystem.hpp>
+#include <algorithm>
 
 
 using std::string;

--- a/src/lib/dcp_subtitle.cc
+++ b/src/lib/dcp_subtitle.cc
@@ -24,6 +24,7 @@
 #include "compose.hpp"
 #include <dcp/interop_subtitle_asset.h>
 #include <dcp/smpte_subtitle_asset.h>
+#include <memory>
 
 #include "i18n.h"
 

--- a/src/lib/dcp_subtitle.h
+++ b/src/lib/dcp_subtitle.h
@@ -24,6 +24,7 @@
 
 
 #include <boost/filesystem.hpp>
+#include <memory>
 
 
 namespace dcp {

--- a/src/lib/zipper.h
+++ b/src/lib/zipper.h
@@ -20,6 +20,7 @@
 
 
 #include <boost/filesystem.hpp>
+#include <memory>
 #include <vector>
 
 

--- a/src/wx/fonts_dialog.cc
+++ b/src/wx/fonts_dialog.cc
@@ -28,6 +28,7 @@
 #include "lib/text_content.h"
 #include <wx/wx.h>
 #include <iostream>
+#include <memory>
 
 
 using std::list;

--- a/src/wx/fonts_dialog.h
+++ b/src/wx/fonts_dialog.h
@@ -25,6 +25,7 @@ DCPOMATIC_DISABLE_WARNINGS
 #include <wx/wx.h>
 DCPOMATIC_ENABLE_WARNINGS
 #include <boost/filesystem.hpp>
+#include <memory>
 
 
 class Content;


### PR DESCRIPTION
`<memory>` is needed for std::*_ptr, and `<algorithm>` for std::transform. This isn't a full IWYU run, just fixing compiler errors as they came up.

Similar to https://github.com/cth103/libcxml/pull/3, trying to get dcpomatic 1.15.x building on NixOS (https://github.com/NixOS/nixpkgs/pull/144680)