### PR TITLE
Allow creating new folders from directory choosers on Linux and macOS

### DIFF
--- a/src/tools/dcpomatic.cc
+++ b/src/tools/dcpomatic.cc
@@ -605,7 +605,7 @@ private:
 			this,
 			_("Select film to open"),
 			std_to_wx(Config::instance()->default_directory_or(wx_to_std(wxStandardPaths::Get().GetDocumentsDir())).string()),
-			wxDEFAULT_DIALOG_STYLE | wxDD_DIR_MUST_EXIST
+			wxDEFAULT_DIALOG_STYLE
 			);
 
 		int r;

--- a/src/tools/dcpomatic_batch.cc
+++ b/src/tools/dcpomatic_batch.cc
@@ -331,7 +331,7 @@ private:
 
 	void add_film ()
 	{
-		wxDirDialog dialog(this, _("Select film to open"), wxStandardPaths::Get().GetDocumentsDir(), wxDEFAULT_DIALOG_STYLE | wxDD_DIR_MUST_EXIST);
+		wxDirDialog dialog(this, _("Select film to open"), wxStandardPaths::Get().GetDocumentsDir(), wxDEFAULT_DIALOG_STYLE);
 		if (_last_parent) {
 			dialog.SetPath(std_to_wx(_last_parent.get().string()));
 		}

--- a/src/tools/dcpomatic_combiner.cc
+++ b/src/tools/dcpomatic_combiner.cc
@@ -65,7 +65,7 @@ class DirDialogWrapper : public DirDialog
 {
 public:
 	DirDialogWrapper (wxWindow* parent)
-		: DirDialog (parent, _("Choose a DCP folder"), wxDD_DIR_MUST_EXIST, "AddCombinerInputPath")
+		: DirDialog (parent, _("Choose a DCP folder"), wxDD_DEFAULT_STYLE, "AddCombinerInputPath")
 	{
 
 	}

--- a/src/tools/dcpomatic_disk.cc
+++ b/src/tools/dcpomatic_disk.cc
@@ -81,7 +81,7 @@ class DirDialogWrapper : public wxDirDialog
 {
 public:
 	DirDialogWrapper(wxWindow* parent)
-		: wxDirDialog(parent, _("Choose a DCP folder"), {}, wxDD_DIR_MUST_EXIST)
+		: wxDirDialog(parent, _("Choose a DCP folder"), {}, wxDD_DEFAULT_STYLE)
 	{
 
 	}

--- a/src/tools/dcpomatic_editor.cc
+++ b/src/tools/dcpomatic_editor.cc
@@ -448,7 +448,7 @@ private:
 
 	void file_open ()
 	{
-		DirDialog dialog(this, _("Select DCP to open"), wxDEFAULT_DIALOG_STYLE | wxDD_DIR_MUST_EXIST, "AddEditorInputPath");
+		DirDialog dialog(this, _("Select DCP to open"), wxDEFAULT_DIALOG_STYLE, "AddEditorInputPath");
 
 		bool r;
 		while (true) {

--- a/src/tools/dcpomatic_player.cc
+++ b/src/tools/dcpomatic_player.cc
@@ -766,7 +766,7 @@ private:
 			d = std_to_wx(Config::instance()->last_player_load_directory()->string());
 		}
 
-		wxDirDialog dialog(this, _("Select DCP to open"), d, wxDEFAULT_DIALOG_STYLE | wxDD_DIR_MUST_EXIST);
+		wxDirDialog dialog(this, _("Select DCP to open"), d, wxDEFAULT_DIALOG_STYLE);
 
 		int r;
 		while (true) {
@@ -796,7 +796,7 @@ private:
 			this,
 			_("Select DCP to open as OV"),
 			initial_dir,
-			wxDEFAULT_DIALOG_STYLE | wxDD_DIR_MUST_EXIST
+			wxDEFAULT_DIALOG_STYLE
 			);
 
 		int r;

--- a/src/wx/content_menu.cc
+++ b/src/wx/content_menu.cc
@@ -379,7 +379,7 @@ ContentMenu::find_missing()
 	boost::filesystem::path path;
 
 	if ((ic && !ic->still()) || dc) {
-		wxDirDialog dialog(nullptr, _("Choose a folder"), {}, wxDD_DIR_MUST_EXIST);
+		wxDirDialog dialog(nullptr, _("Choose a folder"), {}, wxDD_DEFAULT_STYLE);
 		r = dialog.ShowModal();
 		path = wx_to_std(dialog.GetPath());
 	} else {
@@ -487,7 +487,7 @@ ContentMenu::ov()
 
 	auto film = _film.lock();
 	DCPOMATIC_ASSERT(film);
-	DirDialog dialog(_parent, _("Select OV"), wxDD_DIR_MUST_EXIST, "AddFilesPath", dcpomatic::film::add_files_override_path(film));
+	DirDialog dialog(_parent, _("Select OV"), wxDD_DEFAULT_STYLE, "AddFilesPath", dcpomatic::film::add_files_override_path(film));
 
 	if (dialog.show()) {
 		dcp->add_ov(dialog.path());
@@ -649,7 +649,7 @@ ContentMenu::copy_settings()
 	auto film = _film.lock();
 	DCPOMATIC_ASSERT(film);
 
-	DirDialog dialog(_parent, _("Film to copy settings from"), wxDD_DIR_MUST_EXIST, "CopySettingsPath", dcpomatic::film::add_files_override_path(film));
+	DirDialog dialog(_parent, _("Film to copy settings from"), wxDD_DEFAULT_STYLE, "CopySettingsPath", dcpomatic::film::add_files_override_path(film));
 
 	if (!dialog.show()) {
 		return;

--- a/src/wx/content_panel.cc
+++ b/src/wx/content_panel.cc
@@ -631,7 +631,7 @@ ContentPanel::add_file_clicked()
 void
 ContentPanel::add_folder_clicked()
 {
-	DirDialog dialog(_splitter, _("Choose a folder"), wxDD_DIR_MUST_EXIST, "AddFilesPath", dcpomatic::film::add_files_override_path(_film));
+	DirDialog dialog(_splitter, _("Choose a folder"), wxDD_DEFAULT_STYLE, "AddFilesPath", dcpomatic::film::add_files_override_path(_film));
 	if (dialog.show()) {
 		add_folder(dialog.path());
 	}
@@ -674,7 +674,7 @@ ContentPanel::add_folder(boost::filesystem::path folder)
 void
 ContentPanel::add_dcp_clicked()
 {
-	DirDialog dialog(_splitter, _("Choose a DCP folder"), wxDD_DIR_MUST_EXIST, "AddFilesPath", dcpomatic::film::add_files_override_path(_film));
+	DirDialog dialog(_splitter, _("Choose a DCP folder"), wxDD_DEFAULT_STYLE, "AddFilesPath", dcpomatic::film::add_files_override_path(_film));
 	if (dialog.show()) {
 		add_dcp(dialog.path());
 	}

--- a/src/wx/dkdm_output_panel.cc
+++ b/src/wx/dkdm_output_panel.cc
@@ -84,7 +84,7 @@ DKDMOutputPanel::DKDMOutputPanel(wxWindow* parent)
 #ifdef DCPOMATIC_USE_OWN_PICKER
 	_folder = new DirPickerCtrl(this);
 #else
-	_folder = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1));
+	_folder = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 #endif
 
 	auto const path = Config::instance()->default_kdm_directory();

--- a/src/wx/film_name_location_dialog.cc
+++ b/src/wx/film_name_location_dialog.cc
@@ -55,7 +55,7 @@ FilmNameLocationDialog::FilmNameLocationDialog (wxWindow* parent, wxString title
 	_folder = new DirPickerCtrl (this);
 	_folder->Changed.connect (bind(&FilmNameLocationDialog::folder_changed, this));
 #else
-	_folder = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize (300, -1));
+	_folder = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize (300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 	_folder->Bind (wxEVT_DIRPICKER_CHANGED, bind(&FilmNameLocationDialog::folder_changed, this));
 #endif
 

--- a/src/wx/full_config_dialog.cc
+++ b/src/wx/full_config_dialog.cc
@@ -261,7 +261,7 @@ private:
 #ifdef DCPOMATIC_USE_OWN_PICKER
 		_directory = new DirPickerCtrl(_panel);
 #else
-		_directory = new wxDirPickerCtrl(_panel, wxDD_DIR_MUST_EXIST);
+		_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 #endif
 		table->Add(_directory, 1, wxEXPAND);
 
@@ -283,7 +283,7 @@ private:
 #ifdef DCPOMATIC_USE_OWN_PICKER
 		_kdm_directory = new DirPickerCtrl(_panel);
 #else
-		_kdm_directory = new wxDirPickerCtrl(_panel, wxDD_DIR_MUST_EXIST);
+		_kdm_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 #endif
 		table->Add(_kdm_directory, 1, wxEXPAND);
 

--- a/src/wx/grok/gpu_config_panel.h
+++ b/src/wx/grok/gpu_config_panel.h
@@ -22,8 +22,13 @@
 #pragma once
 
 
-#include "lib/grok/util.h"
+#include "wx_util.h"
+#ifdef DCPOMATIC_USE_OWN_PICKER
+#include "dir_picker_ctrl.h"
+#else
 #include <wx/filepicker.h>
+#endif
+#include "lib/grok/util.h"
 
 
 class GpuList : public wxPanel
@@ -103,7 +108,11 @@ private:
 		_panel->GetSizer()->Add(table, 1, wxALL | wxEXPAND, _border);
 
 		add_label_to_sizer(table, _panel, _("Acceleration binary folder"), true, 0, wxLEFT | wxLEFT | wxALIGN_CENTRE_VERTICAL);
+#ifdef DCPOMATIC_USE_OWN_PICKER
+		_binary_location = new DirPickerCtrl(_panel);
+#else
 		_binary_location = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
+#endif
 		table->Add(_binary_location, 1, wxEXPAND);
 
 		add_label_to_sizer(table, _panel, _("GPU selection"), true, 0, wxLEFT | wxRIGHT | wxALIGN_CENTRE_VERTICAL);
@@ -119,7 +128,11 @@ private:
 		table->Add(_licence->get_panel(), 1, wxEXPAND | wxALL);
 
 		_enable_gpu->bind(&GPUPage::enable_gpu_changed, this);
+#ifdef DCPOMATIC_USE_OWN_PICKER
+		_binary_location->Changed.connect(boost::bind(&GPUPage::binary_location_changed, this));
+#else
 		_binary_location->Bind(wxEVT_DIRPICKER_CHANGED, boost::bind (&GPUPage::binary_location_changed, this));
+#endif
 		_server->Bind(wxEVT_TEXT, boost::bind(&GPUPage::server_changed, this));
 		_licence->Changed.connect(boost::bind(&GPUPage::licence_changed, this));
 
@@ -187,7 +200,11 @@ private:
 	}
 
 	CheckBox* _enable_gpu = nullptr;
+#ifdef DCPOMATIC_USE_OWN_PICKER
+	DirPickerCtrl* _binary_location = nullptr;
+#else
 	wxDirPickerCtrl* _binary_location = nullptr;
+#endif
 	GpuList* _gpu_list_control = nullptr;
 	wxTextCtrl* _server = nullptr;
 	PasswordEntry* _licence = nullptr;

--- a/src/wx/grok/gpu_config_panel.h
+++ b/src/wx/grok/gpu_config_panel.h
@@ -103,7 +103,7 @@ private:
 		_panel->GetSizer()->Add(table, 1, wxALL | wxEXPAND, _border);
 
 		add_label_to_sizer(table, _panel, _("Acceleration binary folder"), true, 0, wxLEFT | wxLEFT | wxALIGN_CENTRE_VERTICAL);
-		_binary_location = new wxDirPickerCtrl(_panel, wxDD_DIR_MUST_EXIST);
+		_binary_location = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 		table->Add(_binary_location, 1, wxEXPAND);
 
 		add_label_to_sizer(table, _panel, _("GPU selection"), true, 0, wxLEFT | wxRIGHT | wxALIGN_CENTRE_VERTICAL);

--- a/src/wx/kdm_output_panel.cc
+++ b/src/wx/kdm_output_panel.cc
@@ -80,7 +80,7 @@ KDMOutputPanel::create_destination_widgets(wxWindow* parent)
 #ifdef DCPOMATIC_USE_OWN_PICKER
 	_folder = new DirPickerCtrl(parent);
 #else
-	_folder = new wxDirPickerCtrl(parent, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1));
+	_folder = new wxDirPickerCtrl(parent, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 #endif
 
 	auto path = Config::instance()->default_kdm_directory();

--- a/src/wx/locations_preferences_page.cc
+++ b/src/wx/locations_preferences_page.cc
@@ -64,17 +64,17 @@ LocationsPage::setup()
 	_panel->GetSizer()->Add(table, 1, wxALL | wxEXPAND, _border);
 
 	add_label_to_sizer(table, _panel, _("Content directory"), true, wxGBPosition(r, 0));
-	_content_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1));
+	_content_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 	table->Add(_content_directory, wxGBPosition(r, 1));
 	++r;
 
 	add_label_to_sizer(table, _panel, _("Playlist directory"), true, wxGBPosition(r, 0));
-	_playlist_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1));
+	_playlist_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 	table->Add(_playlist_directory, wxGBPosition(r, 1));
 	++r;
 
 	add_label_to_sizer(table, _panel, _("KDM directory"), true, wxGBPosition(r, 0));
-	_kdm_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1));
+	_kdm_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 	table->Add(_kdm_directory, wxGBPosition(r, 1));
 	++r;
 

--- a/src/wx/locations_preferences_page.cc
+++ b/src/wx/locations_preferences_page.cc
@@ -21,7 +21,11 @@
 
 #include "locations_preferences_page.h"
 #include "wx_util.h"
+#ifdef DCPOMATIC_USE_OWN_PICKER
+#include "dir_picker_ctrl.h"
+#else
 #include <wx/filepicker.h>
+#endif
 #include <wx/gbsizer.h>
 #include <wx/wx.h>
 
@@ -64,23 +68,41 @@ LocationsPage::setup()
 	_panel->GetSizer()->Add(table, 1, wxALL | wxEXPAND, _border);
 
 	add_label_to_sizer(table, _panel, _("Content directory"), true, wxGBPosition(r, 0));
+#ifdef DCPOMATIC_USE_OWN_PICKER
+	_content_directory = new DirPickerCtrl(_panel);
+#else
 	_content_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
+#endif
 	table->Add(_content_directory, wxGBPosition(r, 1));
 	++r;
 
 	add_label_to_sizer(table, _panel, _("Playlist directory"), true, wxGBPosition(r, 0));
+#ifdef DCPOMATIC_USE_OWN_PICKER
+	_playlist_directory = new DirPickerCtrl(_panel);
+#else
 	_playlist_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
+#endif
 	table->Add(_playlist_directory, wxGBPosition(r, 1));
 	++r;
 
 	add_label_to_sizer(table, _panel, _("KDM directory"), true, wxGBPosition(r, 0));
+#ifdef DCPOMATIC_USE_OWN_PICKER
+	_kdm_directory = new DirPickerCtrl(_panel);
+#else
 	_kdm_directory = new wxDirPickerCtrl(_panel, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize(300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
+#endif
 	table->Add(_kdm_directory, wxGBPosition(r, 1));
 	++r;
 
+#ifdef DCPOMATIC_USE_OWN_PICKER
+	_content_directory->Changed.connect(bind(&LocationsPage::content_directory_changed, this));
+	_playlist_directory->Changed.connect(bind(&LocationsPage::playlist_directory_changed, this));
+	_kdm_directory->Changed.connect(bind(&LocationsPage::kdm_directory_changed, this));
+#else
 	_content_directory->Bind(wxEVT_DIRPICKER_CHANGED, bind(&LocationsPage::content_directory_changed, this));
 	_playlist_directory->Bind(wxEVT_DIRPICKER_CHANGED, bind(&LocationsPage::playlist_directory_changed, this));
 	_kdm_directory->Bind(wxEVT_DIRPICKER_CHANGED, bind(&LocationsPage::kdm_directory_changed, this));
+#endif
 }
 
 void

--- a/src/wx/locations_preferences_page.h
+++ b/src/wx/locations_preferences_page.h
@@ -20,8 +20,10 @@
 
 
 #include "preferences_page.h"
+#include "wx_util.h"
 
 
+class DirPickerCtrl;
 class wxDirPickerCtrl;
 
 
@@ -47,9 +49,15 @@ private:
 	void playlist_directory_changed();
 	void kdm_directory_changed();
 
+#ifdef DCPOMATIC_USE_OWN_PICKER
+	DirPickerCtrl* _content_directory;
+	DirPickerCtrl* _playlist_directory;
+	DirPickerCtrl* _kdm_directory;
+#else
 	wxDirPickerCtrl* _content_directory;
 	wxDirPickerCtrl* _playlist_directory;
 	wxDirPickerCtrl* _kdm_directory;
+#endif
 };
 
 

--- a/src/wx/self_dkdm_dialog.cc
+++ b/src/wx/self_dkdm_dialog.cc
@@ -88,7 +88,7 @@ SelfDKDMDialog::SelfDKDMDialog (wxWindow* parent, std::shared_ptr<const Film> fi
 #ifdef DCPOMATIC_USE_OWN_PICKER
 	_folder = new DirPickerCtrl (this);
 #else
-	_folder = new wxDirPickerCtrl (this, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize (300, -1));
+	_folder = new wxDirPickerCtrl (this, wxID_ANY, wxEmptyString, char_to_wx(wxDirSelectorPromptStr), wxDefaultPosition, wxSize (300, -1), wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST);
 #endif
 
 	_folder->SetPath (wxStandardPaths::Get().GetDocumentsDir());

--- a/src/wx/wx_util.cc
+++ b/src/wx/wx_util.cc
@@ -24,6 +24,7 @@
  */
 
 
+#include "dir_picker_ctrl.h"
 #include "file_picker_ctrl.h"
 #include "language_tag_widget.h"
 #include "password_entry.h"
@@ -248,6 +249,21 @@ checked_set(FilePickerCtrl* widget, boost::filesystem::path value)
 
 void
 checked_set(wxDirPickerCtrl* widget, boost::filesystem::path value)
+{
+	if (widget->GetPath() != std_to_wx(value.string())) {
+		if (value.empty()) {
+			/* Hack to make wxWidgets clear the control when we are passed
+			   an empty value.
+			*/
+			value = " ";
+		}
+		widget->SetPath(std_to_wx(value.string()));
+	}
+}
+
+
+void
+checked_set(DirPickerCtrl* widget, boost::filesystem::path value)
 {
 	if (widget->GetPath() != std_to_wx(value.string())) {
 		if (value.empty()) {

--- a/src/wx/wx_util.h
+++ b/src/wx/wx_util.h
@@ -40,6 +40,7 @@ LIBDCP_ENABLE_WARNINGS
 #include <boost/thread.hpp>
 
 
+class DirPickerCtrl;
 class FilePickerCtrl;
 class LanguageTagWidget;
 class RegionSubtagWidget;
@@ -151,6 +152,7 @@ namespace wx {
 
 extern void checked_set(FilePickerCtrl* widget, boost::filesystem::path value);
 extern void checked_set(wxDirPickerCtrl* widget, boost::filesystem::path value);
+extern void checked_set(DirPickerCtrl* widget, boost::filesystem::path value);
 extern void checked_set(wxSpinCtrl* widget, int value);
 extern void checked_set(wxSpinCtrlDouble* widget, double value);
 extern void checked_set(wxChoice* widget, int value);
@@ -171,7 +173,14 @@ extern int wx_get(wxChoice* widget);
 extern int wx_get(wxSpinCtrl* widget);
 extern double wx_get(wxSpinCtrlDouble* widget);
 
-#ifdef DCPOMATIC_WINDOWS
+/* On GTK, wxDirPickerCtrl's native widget (GtkFileChooserButton) does not
+ * support GTK_FILE_CHOOSER_ACTION create-folder at all, so wx hard-codes
+ * wxDD_DIR_MUST_EXIST on its browse dialog regardless of the style passed
+ * to the picker (see wx/gtk/filepicker.h: wxDirButton::GetDialogStyle()).
+ * Use our own picker there too, as on Windows, to get a folder chooser
+ * that actually allows creating a new folder.
+ */
+#if defined(DCPOMATIC_WINDOWS) || defined(__WXGTK__)
 #define DCPOMATIC_USE_OWN_PICKER
 #endif
 


### PR DESCRIPTION
## Problem

On Linux none of the "choose a folder" dialogs offer a way to create a new folder — e.g. File → Open, "Add DCP"/"Add folder", the New Film "Create in folder" browser, and the KDM/DKDM output folder pickers. The same applies on macOS. On Windows the native folder picker always shows a "New folder" button, so the platforms are inconsistent.

## Cause

The dialogs are created with `wxDD_DIR_MUST_EXIST`, and the `wxDirPickerCtrl`s use wx's default style, which includes `wxDIRP_DIR_MUST_EXIST`. wxWidgets maps this flag to disabling folder creation in the native chooser:

- wxGTK (`src/gtk/dirdlg.cpp`): `gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(m_widget), !HasFlag(wxDD_DIR_MUST_EXIST));` — this hides GTK's "Create Folder" button and the context-menu "New Folder" entry.
- wxOSX (`src/osx/cocoa/dirdlg.mm`): `[oPanel setCanCreateDirectories:YES]` only when the flag is absent.
- wxMSW: the flag has no effect on the folder picker — "New folder" is always shown.

A folder chooser can only ever return an existing directory, so the flag's only practical effect is hiding the New Folder affordance on GTK and macOS.

## Change (first commit)

- Drop `wxDD_DIR_MUST_EXIST` from all `wxDirDialog`/`DirDialog` call sites (where it was the entire style, use `wxDD_DEFAULT_STYLE`).
- Pass `wxDIRP_DEFAULT_STYLE & ~wxDIRP_DIR_MUST_EXIST` to the `wxDirPickerCtrl`s (this keeps `wxDIRP_USE_TEXTCTRL` on the platforms whose default includes it).
- `full_config_dialog.cc` and `grok/gpu_config_panel.h` were passing `wxDD_DIR_MUST_EXIST` as the second constructor argument, i.e. as the window ID rather than a style; these now use `wxID_ANY` and an explicit style.

## Testing (first commit)

Ubuntu 26.04, wxGTK 3.2.9: verified before/after on the player's "Select DCP to open" dialog — the "Create Folder" button appears with the change. Also verified with a minimal wx test program that this flag alone toggles the button on this stack, and that the picker-based dialogs ("Select a directory") are governed by the same property. Windows behaviour is unchanged (the flag was already ignored there).

## Update — second commit

The claim above that picker-based dialogs are governed by the same property as a plain `wxDirDialog` turned out to be wrong for GTK, caught by testing the real built app rather than only a synthetic harness. On wxGTK, `wxDirPickerCtrl` is backed by a native `wxDirButton` (`wx/gtk/filepicker.h`) wrapping `GtkFileChooserButton`, which unconditionally forces `wxDD_DIR_MUST_EXIST` on its browse dialog regardless of the picker's own style:

```cpp
// GtkFileChooserButton does not support GTK_FILE_CHOOSER_CREATE_FOLDER
// thus we must ensure that the wxDD_DIR_MUST_EXIST style was given
long GetDialogStyle() const wxOVERRIDE
{
    return (wxGenericDirButton::GetDialogStyle() | wxDD_DIR_MUST_EXIST);
}
```

So every `wxDirPickerCtrl`-based folder field (New Film's "Create in folder", the Preferences folder pickers, KDM/DKDM output folders, the GPU binary location) was still stuck without "New Folder", regardless of the first commit's style change — this is a structural limitation of `GtkFileChooserButton`, not something fixable via style flags.

DCP-o-matic already has its own `DirPickerCtrl` (a plain button that pops a real `wxDirDialog`, which the first commit's fix does work correctly on) for exactly this reason on Windows (`DCPOMATIC_USE_OWN_PICKER`). This commit extends that macro to `__WXGTK__` too, and adds the own-picker branch to the two files that didn't have one yet (`locations_preferences_page.cc`, `grok/gpu_config_panel.h`). macOS is untouched: `wxDirPickerCtrl` there falls through to the generic `wxGenericDirButton` implementation, which has no such override, so the original style-flag fix already works fine there.

Verified end-to-end on the real built app (not just a synthetic harness), Ubuntu 26.04 / wxGTK 3.2.9: New Film's folder picker, Preferences → Locations, and Preferences → GPU all show "New Folder" and support Ctrl+Shift+N now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
